### PR TITLE
Landos refactor

### DIFF
--- a/EVSL_1.0/INC/def.h
+++ b/EVSL_1.0/INC/def.h
@@ -19,17 +19,31 @@
 #define CHKERR(ierr) assert(!(ierr))
 //#define CHKREQ(ierr) { if (ierr) { return (ierr); } }
 
-#define Malloc(base, nmem, type) {\
-  (base) = (type*) malloc((nmem)*sizeof(type)); \
-  CHKERR((base) == NULL); \
+#define Malloc(base, nmem, type) { \
+  size_t nbytes = (nmem) * sizeof(type); \
+  (base) = (type*) malloc(nbytes); \
+  if ((base) == NULL) { \
+    fprintf(stdout, "EVSL Error: out of memory [%ld bytes asked]\n", nbytes); \
+    exit(-1); \
+  } \
 }
-#define Calloc(base, nmem, type) {\
+
+#define Calloc(base, nmem, type) { \
+  size_t nbytes = (nmem) * sizeof(type); \
   (base) = (type*) calloc((nmem), sizeof(type)); \
-  CHKERR((base) == NULL); \
+  if ((base) == NULL) { \
+    fprintf(stdout, "EVSL Error: out of memory [%ld bytes asked]\n", nbytes); \
+    exit(-1); \
+  } \
 }
+
 #define Realloc(base, nmem, type) {\
-  (base) = (type*) realloc((base), (nmem)*sizeof(type)); \
-  CHKERR((base) == NULL && nmem > 0); \
+  size_t nbytes = (nmem) * sizeof(type); \
+  (base) = (type*) realloc((base), nbytes); \
+  if ((base) == NULL) { \
+    fprintf(stdout, "EVSL Error: out of memory [%ld bytes asked]\n", nbytes); \
+    exit(-1); \
+  } \
 }
 
 /*!

--- a/EVSL_1.0/INC/evsl.h
+++ b/EVSL_1.0/INC/evsl.h
@@ -34,17 +34,17 @@ int ChebSI(int nev, double *intv, int maxit, double tol, double *vinit,
            FILE *fstats);
 
 /*- - - - - - - - - - dos_utils.c */
-void SetupBSolPol(csrMat *B, BSolDataPol *data);
+void SetupPolRec(int n, int max_deg, double tol, double lmin, double lmax, BSolDataPol *data);
 //
-void SetupBsqrtSolPol(csrMat *B, BSolDataPol *data);
+void SetupPolSqrt(int n, int max_deg, double tol, double lmin, double lmax, BSolDataPol *data);
 //
 void FreeBSolPolData(BSolDataPol *data);
 //
 void BSolPol(double *b, double *x, void *data);
 //
-void extractDiag(cooMat *B, double *sqrtdiag);
+void extrDiagCsr(csrMat *B, double *d);
 //
-void diagScaling(cooMat *A, cooMat *B, double *sqrtdiag);
+void diagScalCsr(csrMat *A, double *d);
 
 /*- - - - - - - - - lanbounds.c */
 int LanBounds(int msteps, double *v, double *lmin, double *lmax);
@@ -55,9 +55,8 @@ int LanDos(const int nvec, int msteps, const int npts, double *xdos,
            double *ydos, double *neig, const double *const intv);
 
 //*- - - - - - - - -  landosG.c - Generalized lanDOS */
-int LanDosG(const int nvec, int msteps, const int degB, const int npts,
-            double *xdos, double *ydos, double *neig, const double *const intv,
-            const double tau);
+int LanDosG(const int nvec, int msteps, const int npts, double *xdos, double *ydos,
+            double *neig, const double *const intv);
 
 /*- - - - - - - - - lanTrbounds.c */
 int LanTrbounds(int lanm, int maxit, double tol, double *vinit, int bndtype,
@@ -91,6 +90,7 @@ int RatLanTr(int lanm, int nev, double *intv, int maxit, double tol,
              double **W, double **resW, FILE *fstats);
 
 /*- - - - - - - - - spmat.c */
+void csr_copy(csrMat *A, csrMat *B, int allocB);
 // convert a COO matrix to a CSR matrix
 int cooMat_to_csrMat(int cooidx, cooMat *coo, csrMat *csr);
 // free a CSR
@@ -118,6 +118,7 @@ int SetGenEig();
 int EVSLStart();
 /* finalize EVSL */
 int EVSLFinish();
+void SetDiagScal(double *ds);
 
 /*- - - - - - - - - spslicer.c */
 //

--- a/EVSL_1.0/INC/internal_proto.h
+++ b/EVSL_1.0/INC/internal_proto.h
@@ -32,8 +32,7 @@ double isqrt(const double a);
 int pnav(double *mu, const int m, const double cc, const double dd, double *v,
          double *y, double *w);  // Really just ChebAv
 //
-int lsPol(const double *const intv, const int maxDeg, double (*ffun)(double),
-          const double npts, polparams *pol);
+int lsPol(double (*ffun)(double), BSolDataPol *pol);
 
 /*- - - - - - - - - dump.c */
 //
@@ -144,6 +143,19 @@ static inline void solve_B(double *x, double *y) {
   double tme = cheblan_timer();
   evslstat.t_svB += tme - tms;
   evslstat.n_svB ++;
+}
+
+/**
+* @brief y = LT \ x or y = SQRT(B) \ x
+* This is the solve function for the matrix B in evsldata
+*/
+static inline void solve_LT(double *x, double *y) {
+  CHKERR(!evsldata.LTsol);
+  double tms = cheblan_timer();
+  evsldata.LTsol->func(x, y, evsldata.LTsol->data);
+  double tme = cheblan_timer();
+  evslstat.t_svLT += tme - tms;
+  evslstat.n_svLT ++;
 }
 
 /**

--- a/EVSL_1.0/INC/struct.h
+++ b/EVSL_1.0/INC/struct.h
@@ -50,7 +50,7 @@ typedef struct _polparams {
   int damping;        /**< 0 = no damping, 1 = Jackson, 2 = Lanczos */
   double thresh_ext;  /**< threshold for accepting polynom. for end intervals */
   double thresh_int;  /**< threshold for interior intervals */
-  double tol;    /**< tolerance for LS approxiamtion */
+  double tol;         /**< tolerance for LS approxiamtion */
   /**@}*/
   
   /** @name output from find_pol */
@@ -165,15 +165,21 @@ typedef struct _evsldata {
   EVSLMatvec *Bmv;          /**< matvec routine and the associated data for B */
   EVSLBSol *Bsol;           /**< function and data for B solve */
   EVSLLTSol *LTsol;         /**< function and data for LT solve */
+  double *ds;               /**< diagonal scaling matrix D,
+                                 D^{-1}*A*D^{-1} = \lambda * D^{-1}*B*D^{-1} */
 } evslData;
 
 /*
- * Define a struct for using polynomial to solve B
+ * Define a struct for L-S polynomial approximation to a matrix function
  */
 typedef struct _BSolDataPol {
-  polparams pol_sol; // polynomial for approximating B^{-1}
-  double *wk; // working array for performing matvec
-  double intv[2]; // spectrum range of B 
+  int max_deg;    /**< max degree set by user */
+  int deg;        /**< actual degree of the polynomial */
+  double intv[2]; /**< spectrum bounds of the matrix */
+  double cc, dd;  /**< center and half-width */
+  double tol;     /**< approx. tolerance */
+  double *mu;     /**< polyno. coeff */
+  double *wk;     /**< working array for applying */
 } BSolDataPol;
 
 
@@ -193,11 +199,13 @@ typedef struct _evslstat {
   double t_mvA;
   double t_mvB;
   double t_svB;
+  double t_svLT;
   double t_svASigB;
   double t_reorth;
   size_t n_mvA;
   size_t n_mvB;
   size_t n_svB;
+  size_t n_svLT;
   size_t n_svASigB;
   /* memory */
   size_t alloced;

--- a/EVSL_1.0/SRC/chebpoly.c
+++ b/EVSL_1.0/SRC/chebpoly.c
@@ -441,7 +441,7 @@ int find_pol(double *intv, polparams *pol) {
     for (j=0; j<min_deg; j++)
       v[j] = cos(j*thb) - cos(j*tha);
     /*-------------------- DEGREE LOOP -------------------- */
-    for (m=min_deg; m < max_deg;m++){
+    for (m=min_deg; m < max_deg; m++){
       dampcf(m, damping, jac);
       //-------------------- update v: add one more entry
       v[m] = cos(m*thb)-cos(m*tha);

--- a/EVSL_1.0/SRC/evsl.c
+++ b/EVSL_1.0/SRC/evsl.c
@@ -31,6 +31,7 @@ int EVSLStart() {
   evsldata.Bmv = NULL;
   evsldata.Bsol = NULL;
   evsldata.LTsol = NULL;
+  evsldata.ds = NULL;
 
   StatsReset();
   
@@ -185,5 +186,12 @@ int SetLTSol(SolFuncR func, void *data) {
   evsldata.LTsol->func = func;
   evsldata.LTsol->data = data;
   return 0;
+}
+
+/**
+ * @brief Set diagonal scaling matrix D
+ * */
+void SetDiagScal(double *ds) {
+  evsldata.ds = ds;
 }
 

--- a/EVSL_1.0/SRC/landos.c
+++ b/EVSL_1.0/SRC/landos.c
@@ -21,8 +21,8 @@
  *    @param[in] msteps number of Lanczos steps
  *    @param[in] npts number of sample points used for the DOS curve
  *    @param[in] *intv Stores the two intervals of interest \\
- *      intv[0:1] = [lambda_min, lambda_max]\\
- *      intv[2:3] = [a b] = interval where DOS is to be computed
+ *      intv[0:1] = [a b] = interval where DOS is to be computed
+ *      intv[2:3] = [lambda_min, lambda_max]\\
  *
  *    @param[out] *xdos Length-npts long vector, x-coordinate points for
  *    plotting the DOS. Must be preallocated before calling LanDos
@@ -66,8 +66,8 @@ int LanDos(const int nvec, int msteps, int npts, double *xdos, double *ydos,
   Malloc(S, msteps * msteps, double);
   Malloc(gamma2, msteps, double);
   Malloc(ritzVal, msteps, double);
-  const double lm = intv[0];
-  const double lM = intv[1];
+  const double lm = intv[2];
+  const double lM = intv[3];
   const double tolBdwn = 1.e-13 * (abs(lM) + abs(lm));
   const double aa = max(intv[0], intv[2]);
   const double bb = min(intv[1], intv[3]);

--- a/EVSL_1.0/SRC/misc_la.c
+++ b/EVSL_1.0/SRC/misc_la.c
@@ -249,22 +249,4 @@ void orth(double *V, int n, int k, double *Vo, double *work) {
     DSCAL(&n, &t, Vo+istart, &one); 
   }
 }
-/*
- * Recover the eigenvectors This is needed for GEN_MM folder only not DOS folder
- */
-int scalEigVec(int n, int nev, double *Y, double* sqrtdiag) {
-  // Formula (2.19) in the paper.  Y(:,i) is x in the paper and D^{1/2} is sqrtdiag here
-  // n: matrix size
-  // nev: number of eigenvectors V: n*nev
-  // V: computed eigenvectors
-  // sqrtdiag: square root of diagonal entries of B
-  int i, j;
-  double *v;
-  for (i=0; i<nev; i++){
-    v = &Y[i*n];
-    for (j=0; j<n; j++) {
-      v[j] = v[j]*sqrtdiag[j];
-    }
-  }
-  return 0;
-}
+

--- a/EVSL_1.0/SRC/ratlanNr.c
+++ b/EVSL_1.0/SRC/ratlanNr.c
@@ -365,14 +365,21 @@ int RatLanNr(double *intv, int maxit, double tol, double *vinit,
     if (ifGenEv) {
       /*-------------------- w = w - t*B*u */
       DAXPY(&n, &nt, w2, &one, wk, &one);
-      /*-------------------- 2 norm of res */
-      res0 = DNRM2(&n, wk, &one);
     } else {
       /*-------------------- w = w - t*u */
       DAXPY(&n, &nt, u, &one, wk, &one);
-      /*-------------------- res0 = norm(w) */
-      res0 = DNRM2(&n, wk, &one); 
     }
+    /*-------------------- if diag scaling is present */
+    if (evsldata.ds) {
+      /* scale the residual */
+      int j;
+      for (j=0; j<n; j++) {
+        /* NOTE that we saved reciprocal of the diag scaling */
+        wk[j] /= evsldata.ds[j];
+      }
+    }
+    /*-------------------- res0 = 2-norm(wk) */
+    res0 = DNRM2(&n, wk, &one); 
     /*--------------------   accept (t, y) */
     if (res0 < tol) {
       Lam[nev] = t;

--- a/EVSL_1.0/SRC/ratlanTr.c
+++ b/EVSL_1.0/SRC/ratlanTr.c
@@ -427,6 +427,8 @@ int RatLanTr(int lanm, int nev, double *intv, int maxit,
           break;
         }
 #if 1
+        /* we change the convergence test to be simple:
+         * we test if the sum and the number of the Ritz values that are >= bar no longer change */
         jl = 0;
         tr = 0.0;
         for (i=0; i<k; i++) {
@@ -549,14 +551,21 @@ int RatLanTr(int lanm, int nev, double *intv, int maxit,
         if (ifGenEv) {
           /* w = w - t3*w2, w2 = B*y,  (w=A*y-t3*B*y) */
           DAXPY(&n, &nt3, w2, &one, w, &one);
-          /* res0 = 2-norm of w */
-          res0 = DNRM2(&n, w, &one);
         } else {
           /*-------------------- w = w - t3*y, (w=A*y-t3*y) */
           DAXPY(&n, &nt3, y, &one, w, &one);
-          /*-------------------- res0 = norm(w) */
-          res0 = DNRM2(&n, w, &one);
         }
+        /*-------------------- if diag scaling is present */
+        if (evsldata.ds) {
+          /* scale the residual */
+          int j;
+          for (j=0; j<n; j++) {
+            /* NOTE that we saved reciprocal of the diag scaling */
+            w[j] /= evsldata.ds[j];
+          }
+        }
+        /*-------------------- res0 = 2-norm of w */
+        res0 = DNRM2(&n, w, &one);
         /*-------------------- test res. of this Ritz pair against tol */
         /* r = resi[i];*/
         r = res0;

--- a/EVSL_1.0/SRC/spslice.c
+++ b/EVSL_1.0/SRC/spslice.c
@@ -81,8 +81,8 @@ int kpmdos(int Mdeg, int damping, int nvec, double *intv,
       rand_double(n, v);
       t = 1.0 / DNRM2(&n, v, &one);
       DSCAL(&n, &t, v, &one);  
-      /*  w = L^{-T}v */
-      evsldata.LTsol->func(v, w, evsldata.LTsol->data);
+      /*  w = L^{-T}*v */
+      solve_LT(v, w);
       /* v = B*w */
       matvec_B(w, v);
       t = DDOT(&n, v, &one, w, &one);

--- a/EVSL_1.0/TESTS/COMMON/io.c
+++ b/EVSL_1.0/TESTS/COMMON/io.c
@@ -103,10 +103,11 @@ int read_coo_MM(const char *matfile, int idxin, int idxout, cooMat *Acoo) {
    * so nnz2 <= 2*nnz 
    *-------------------------------------*/
   if (mm_is_symmetric(matcode)){
-    printf(" * * * *  matrix is symmetric * * * * \n");
-    nnz2 = 2*nnz;}
-  else
+    /* printf(" * * * *  matrix is symmetric * * * * \n"); */
+    nnz2 = 2*nnz;
+  } else {
     nnz2 = nnz;
+  }
   /*-------- Allocate mem for COO */
   int* IR = (int *)malloc(nnz2*sizeof(int));
   int* JC = (int *)malloc(nnz2*sizeof(int));

--- a/EVSL_1.0/TESTS/COMMON_GEN/io.c
+++ b/EVSL_1.0/TESTS/COMMON_GEN/io.c
@@ -109,10 +109,11 @@ int read_coo_MM(const char *matfile, int idxin, int idxout, cooMat *Acoo) {
    * so nnz2 <= 2*nnz 
    *-------------------------------------*/
   if (mm_is_symmetric(matcode)){
-    printf(" * * * *  matrix is symmetric * * * * \n");
-    nnz2 = 2*nnz;}
-  else
+    /*printf(" * * * *  matrix is symmetric * * * * \n");*/
+    nnz2 = 2*nnz;
+  } else {
     nnz2 = nnz;
+  }
   /*-------- Allocate mem for COO */
   int* IR = (int *)malloc(nnz2*sizeof(int));
   int* JC = (int *)malloc(nnz2*sizeof(int));

--- a/EVSL_1.0/TESTS/GEN/KPM_MMRLanN.c
+++ b/EVSL_1.0/TESTS/GEN/KPM_MMRLanN.c
@@ -1,8 +1,8 @@
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <math.h>
 #include "io.h"
 #include "evsl.h"
 #include "evsl_direct.h"
@@ -21,11 +21,11 @@ int main() {
    * read in matrix format -- using
    * Thick-Restarted Lanczos with rational filtering.
    *-------------------------------------------------------------*/
-  int n = 0, nnz = 0, i, j, npts, nslices, nvec, Mdeg, nev, max_its, ev_int, sl,
+  int n = 0, i, j, npts, nslices, nvec, Mdeg, nev, max_its, ev_int, sl,
       ierr, totcnt;
   /* find the eigenvalues of A in the interval [a,b] */
   double a, b, lmax, lmin, ecount, tol, *sli, *mu;
-  double xintv[6];
+  double xintv[4];
   double *alleigs;
   int *counts; // #ev computed in each slice
   /* initial vector: random */
@@ -36,7 +36,7 @@ int main() {
   double beta = 0.01; // beta in the LS approximation
   /*-------------------- matrices A, B: coo format and csr format */
   cooMat Acoo, Bcoo;
-  csrMat Acsr, Bcsr;
+  csrMat Acsr, Bcsr, Acsr0, Bcsr0;
   double *sqrtdiag = NULL;
   /* slicer parameters */
   Mdeg = 80;
@@ -93,7 +93,7 @@ int main() {
     }
 
     char path[1024]; // path to write the output files
-    strcpy(path, "OUT/MMRLanN_");
+    strcpy(path, "OUT/KPM_MMRLanN_");
     strcat(path, io.MatNam1);
     fstats = fopen(path, "w"); // write all the output to the file io.MatNam
     if (!fstats) {
@@ -102,9 +102,8 @@ int main() {
     }
     fprintf(fstats, "MATRIX A: %s...\n", io.MatNam1);
     fprintf(fstats, "MATRIX B: %s...\n", io.MatNam2);
-    fprintf(fstats,
-            "Partition the interval of interest [%f,%f] into %d slices\n", a, b,
-            nslices);
+    fprintf(fstats, "Partition the interval of interest [%f,%f] into %d slices\n",
+            a, b, nslices);
     counts = malloc(nslices * sizeof(int));
     sli = malloc((nslices + 1) * sizeof(double));
     /*-------------------- Read matrix - case: COO/MatrixMarket formats */
@@ -112,10 +111,7 @@ int main() {
       ierr = read_coo_MM(io.Fname1, 1, 0, &Acoo);
       if (ierr == 0) {
         fprintf(fstats, "matrix read successfully\n");
-        nnz = Acoo.nnz;
         n = Acoo.nrows;
-        printf("size of A is %d\n", n);
-        printf("nnz of  A is %d\n", nnz);
       } else {
         fprintf(flog, "read_coo error for A = %d\n", ierr);
         exit(6);
@@ -123,55 +119,56 @@ int main() {
       ierr = read_coo_MM(io.Fname2, 1, 0, &Bcoo);
       if (ierr == 0) {
         fprintf(fstats, "matrix read successfully\n");
-        nnz = Bcoo.nnz;
-        n = Bcoo.nrows;
-        printf("size of B is %d\n", n);
-        printf("nnz of  B is %d\n", nnz);
+        if (Bcoo.nrows != n) {
+          return 1;
+        }
       } else {
         fprintf(flog, "read_coo error for B = %d\n", ierr);
         exit(6);
       }
       /*------------------ diagonal scaling for Acoo and Bcoo */
       sqrtdiag = (double *)calloc(n, sizeof(double));
-      extractDiag(&Bcoo, sqrtdiag);
-      diagScaling(&Acoo, &Bcoo, sqrtdiag);
-      /*-------------------- conversion from COO to CSR format */
+      /*------------------ conversion from COO to CSR format */
       ierr = cooMat_to_csrMat(0, &Acoo, &Acsr);
       ierr = cooMat_to_csrMat(0, &Bcoo, &Bcsr);
-    }
-    if (io.Fmt == HB) {
-      fprintf(flog, "HB FORMAT  not supported (yet) * \n");
+    } else if (io.Fmt == HB) {
+      fprintf(flog, "HB FORMAT not supported (yet) * \n");
       exit(7);
     }
-    alleigs = malloc(n * sizeof(double));
-    /*----------------  compute the range of the spectrum of B */
+
+    /*-------------------- diagonal scaling for L-S poly. approx. 
+     *                     of B^{-1} and B^{-1/2},
+     *                     which will be used in the DOS */
+    /*-------------------- sqrt of diag(B) */
+    extrDiagCsr(&Bcsr, sqrtdiag);
+    for (i=0; i<n; i++) {
+      sqrtdiag[i] = sqrt(sqrtdiag[i]);
+    }
+    /*-------------------- backup A and B */
+    csr_copy(&Acsr, &Acsr0, 1); /* 1 stands for memory alloc */
+    csr_copy(&Bcsr, &Bcsr0, 1);
+    /*-------------------- Scale A and B */
+    diagScalCsr(&Acsr, sqrtdiag);
+    diagScalCsr(&Bcsr, sqrtdiag);
+    if (sqrtdiag) {
+      free(sqrtdiag);
+    }
+
+    /*---------------- Set EVSL to solve std eig problem to
+     *---------------- compute the range of the spectrum of B */
     SetStdEig();
     SetAMatrix(&Bcsr);
     vinit = (double *)malloc(n * sizeof(double));
     rand_double(n, vinit);
     ierr = LanTrbounds(50, 200, 1e-10, vinit, 1, &lmin, &lmax, fstats);
-    /*------------- get the bounds for B ------*/
-    xintv[4] = lmin;
-    xintv[5] = lmax;
-    /*---------------  Pass the bounds to Bsol2 and Bsqrtsol */
-    Bsol.intv[0] = lmin;
-    Bsol.intv[1] = lmax;
-    Bsqrtsol.intv[0] = lmin;
-    Bsqrtsol.intv[1] = lmax;
-    /*--------------  Setup the Bsol and Bsqrtsol struct */
-    set_pol_def(&Bsol.pol_sol);
-    (Bsol.pol_sol).max_deg = degB;
-    (Bsol.pol_sol).tol = tau;
-    SetupBSolPol(&Bcsr, &Bsol);
-    set_pol_def(&Bsqrtsol.pol_sol);
-    (Bsqrtsol.pol_sol).max_deg = degB;
-    (Bsqrtsol.pol_sol).tol = tau;
-    SetupBsqrtSolPol(&Bcsr, &Bsqrtsol);
-    printf("The degree for LS approximations to B^{-1} and B^{-1/2} are %d and "
-           "%d\n",
-           (Bsol.pol_sol).deg, (Bsqrtsol.pol_sol).deg);
-    SetBSol(BSolPol, (void *)&Bsol);
+    /*-------------------- Use polynomial to solve B and sqrt(B) */
+    /*-------------------- Setup the Bsol and Bsqrtsol struct */
+    SetupPolRec (n, degB, tau, lmin, lmax, &Bsol);
+    SetupPolSqrt(n, degB, tau, lmin, lmax, &Bsqrtsol);
+    SetBSol (BSolPol, (void *)&Bsol);
     SetLTSol(BSolPol, (void *)&Bsqrtsol);
+    printf("The degree for LS polynomial approximations to B^{-1} and B^{-1/2} "
+           "are %d and %d\n", Bsol.deg, Bsqrtsol.deg);
     /*-------------------- set the left-hand side matrix A */
     SetAMatrix(&Acsr);
     /*-------------------- set the right-hand side matrix B */
@@ -190,7 +187,7 @@ int main() {
     xintv[2] = lmin;
     xintv[3] = lmax;
     /*-------------------- call kpmdos to get the DOS for dividing the
-     * spectrum*/
+     *                     spectrum*/
     /*-------------------- define kpmdos parameters */
     //-------------------- call kpmdos
     double t = cheblan_timer();
@@ -215,9 +212,21 @@ int main() {
     for (j = 0; j < nslices; j++) {
       printf(" %2d: [% .15e , % .15e]\n", j + 1, sli[j], sli[j + 1]);
     }
+    /*-------------------- DONE WITH DOS */
+    FreeBSolPolData(&Bsol);
+    FreeBSolPolData(&Bsqrtsol);
+
     //-------------------- # eigs per slice
     ev_int = (int)(1 + ecount / ((double)nslices));
     totcnt = 0;
+    alleigs = malloc(n * sizeof(double));
+ 
+    /* recover the original matrices A and B before scaling 
+     * Note that B-sol and sqrt(B)-sol will not be needed in RatLan,
+     * so we can recover them */
+    csr_copy(&Acsr0, &Acsr, 0); /* 0 stands for no memory alloc */
+    csr_copy(&Bcsr0, &Bcsr, 0);
+
     //-------------------- For each slice call RatLanrNr
     for (sl = 0; sl < nslices; sl++) {
       printf("======================================================\n");
@@ -243,7 +252,7 @@ int main() {
       rat.beta = beta;
       // now determine rational filter
       find_ratf(intv, &rat);
-      // use direct solver function 
+      // use direct solver function
       void **solshiftdata = (void **)malloc(num * sizeof(void *));
       /*------------ factoring the shifted matrices and store the factors */
       SetupASIGMABSolDirect(&Acsr, &Bcsr, num, rat.zk, solshiftdata);
@@ -292,7 +301,7 @@ int main() {
     } // for (sl=0; sl<nslices; sl++)
     //-------------------- free other allocated space
     fprintf(fstats, " --> Total eigenvalues found = %d\n", totcnt);
-    sprintf(path, "OUT/EigsOut_RLanN_(%s, %s)", io.MatNam1, io.MatNam2);
+    sprintf(path, "OUT/EigsOut_KPM_MMRLanN_(%s_%s)", io.MatNam1, io.MatNam2);
     FILE *fmtout = fopen(path, "w");
     if (fmtout) {
       for (j = 0; j < totcnt; j++)
@@ -305,22 +314,21 @@ int main() {
     free_csr(&Acsr);
     free_coo(&Bcoo);
     free_csr(&Bcsr);
-    FreeBSolPolData(&Bsol);
-    FreeBSolPolData(&Bsqrtsol);
+    free_csr(&Acsr0);
+    free_csr(&Bcsr0);
     free(alleigs);
     free(counts);
-    if (sqrtdiag)
-      free(sqrtdiag);
-    if (fstats != stdout)
+    if (fstats != stdout) {
       fclose(fstats);
+    }
     /*-------------------- end matrix loop */
   }
   free(mu);
-  if (flog != stdout)
+  if (flog != stdout) {
     fclose(flog);
+  }
   fclose(fmat);
   /*-------------------- finalize EVSL */
   EVSLFinish();
   return 0;
 }
-

--- a/EVSL_1.0/TESTS/GEN/Lan_MMPLanR.c
+++ b/EVSL_1.0/TESTS/GEN/Lan_MMPLanR.c
@@ -21,11 +21,10 @@ int main() {
    * read in matrix format -- using
    * Thick-Restarted Lanczos with polynomial filtering.
    *-------------------------------------------------------------*/
-  int n = 0, i, j, npts, nslices, nvec, nev, mlan, max_its, ev_int, sl, ierr,
-      totcnt;
+  int n = 0, i, j, npts, nslices, nvec, nev, mlan, max_its, ev_int, sl, ierr, totcnt;
   /* find the eigenvalues of A in the interval [a,b] */
   double a, b, lmax, lmin, ecount, tol, *sli;
-  double xintv[6];
+  double xintv[4];
   double *alleigs;
   int *counts; // #ev computed in each slice
   /* initial vector: random */
@@ -34,7 +33,6 @@ int main() {
   /*-------------------- matrices A, B: coo format and csr format */
   cooMat Acoo, Bcoo;
   csrMat Acsr, Bcsr;
-  double *sqrtdiag = NULL;
   /* slicer parameters */
   int msteps = 40;
   nvec = 10;
@@ -42,8 +40,6 @@ int main() {
   FILE *flog = stdout, *fmat = NULL;
   FILE *fstats = NULL;
   io_t io;
-  const int degB = 200;    // Max degree to aproximate B with
-  const double tau = 1e-4; // Tolerance in polynomial approximation
   int numat, mat;
   char line[MAX_LINE];
   /*-------------------- Bsol */
@@ -90,7 +86,7 @@ int main() {
     }
 
     char path[1024]; // path to write the output files
-    strcpy(path, "OUT/MMPLanR_");
+    strcpy(path, "OUT/Lan_MMPLanR_");
     strcat(path, io.MatNam1);
     fstats = fopen(path, "w"); // write all the output to the file io.MatNam
     if (!fstats) {
@@ -99,9 +95,8 @@ int main() {
     }
     fprintf(fstats, "MATRIX A: %s...\n", io.MatNam1);
     fprintf(fstats, "MATRIX B: %s...\n", io.MatNam2);
-    fprintf(fstats,
-            "Partition the interval of interest [%f,%f] into %d slices\n", a, b,
-            nslices);
+    fprintf(fstats, "Partition the interval of interest [%f,%f] into %d slices\n", 
+            a, b, nslices);
     counts = malloc(nslices * sizeof(int));
     sli = malloc((nslices + 1) * sizeof(double));
     /*-------------------- Read matrix - case: COO/MatrixMarket formats */
@@ -123,38 +118,19 @@ int main() {
         if (Bcoo.nrows != n) {
           return 1;
         }
-        // nnz = Bcoo.nnz;
-        // n = Bcoo.nrows;
-        // printf("size of B is %d\n", n);
-        // printf("nnz of  B is %d\n", nnz);
       } else {
         fprintf(flog, "read_coo error for B = %d\n", ierr);
         exit(6);
       }
-      /*------------------ diagonal scaling for Acoo and Bcoo */
-      sqrtdiag = (double *)calloc(n, sizeof(double));
-      extractDiag(&Bcoo, sqrtdiag);
-      diagScaling(&Acoo, &Bcoo, sqrtdiag);
       /*-------------------- conversion from COO to CSR format */
       ierr = cooMat_to_csrMat(0, &Acoo, &Acsr);
       ierr = cooMat_to_csrMat(0, &Bcoo, &Bcsr);
-    }
-    if (io.Fmt == HB) {
+    } else if (io.Fmt == HB) {
       fprintf(flog, "HB FORMAT  not supported (yet) * \n");
       exit(7);
     }
     alleigs = malloc(n * sizeof(double));
-    /*----------------  compute the range of the spectrum of B */
-    SetStdEig();
-    SetAMatrix(&Bcsr);
-    vinit = (double *)malloc(n * sizeof(double));
-    rand_double(n, vinit);
-    ierr = LanTrbounds(50, 200, 1e-10, vinit, 1, &lmin, &lmax, fstats);
-    /*------------- get the bounds for B ------*/
-    xintv[4] = lmin;
-    xintv[5] = lmax;
-    /*-------------------- use CXSparse as the solver for B  in eigenvalue
-     * computation*/
+    /*-------------------- use direct solver as the solver for B */
     SetupBSolDirect(&Bcsr, &Bsol);
     /*-------------------- set the solver for B and LT */
     SetBSol(BSolDirect, Bsol);
@@ -167,23 +143,22 @@ int main() {
     SetGenEig();
     /*-------------------- step 0: get eigenvalue bounds */
     //-------------------- initial vector
+    vinit = (double *)malloc(n * sizeof(double));
     rand_double(n, vinit);
     ierr = LanTrbounds(50, 200, 1e-12, vinit, 1, &lmin, &lmax, fstats);
     fprintf(fstats, "Step 0: Eigenvalue bound s for B^{-1}*A: [%.15e, %.15e]\n",
             lmin, lmax);
     /*-------------------- interval and eig bounds */
-    xintv[0] = lmin;
-    xintv[1] = lmax;
-    xintv[2] = a;
-    xintv[3] = b;
-    /*-------------------- call kpmdos to get the DOS for dividing the
-     * spectrum*/
+    xintv[0] = a;
+    xintv[1] = b;
+    xintv[2] = lmin;
+    xintv[3] = lmax;
+    /*-------------------- call LanczosDOS for spectrum slicing */
     /*-------------------- define landos parameters */
-    //-------------------- call landos
     double t = cheblan_timer();
     double *xdos = (double *)calloc(npts, sizeof(double));
     double *ydos = (double *)calloc(npts, sizeof(double));
-    ierr = LanDosG(nvec, msteps, degB, npts, xdos, ydos, &ecount, xintv, tau);
+    ierr = LanDosG(nvec, msteps, npts, xdos, ydos, &ecount, xintv);
     t = cheblan_timer() - t;
     if (ierr) {
       printf("Landos error %d\n", ierr);
@@ -258,7 +233,6 @@ int main() {
       memcpy(&alleigs[totcnt], lam, nev2 * sizeof(double));
       totcnt += nev2;
       counts[sl] = nev2;
-      ierr = scalEigVec(n, nev2, Y, sqrtdiag);
       //-------------------- free allocated space withing this scope
       if (lam)
         free(lam);
@@ -271,7 +245,7 @@ int main() {
     } // for (sl=0; sl<nslices; sl++)
     //-------------------- free other allocated space
     fprintf(fstats, " --> Total eigenvalues found = %d\n", totcnt);
-    sprintf(path, "OUT/EigsOut_PLanR_(%s_%s)", io.MatNam1, io.MatNam2);
+    sprintf(path, "OUT/EigsOut_Lan_MMPLanR_(%s_%s)", io.MatNam1, io.MatNam2);
     FILE *fmtout = fopen(path, "w");
     if (fmtout) {
       for (j = 0; j < totcnt; j++)
@@ -289,16 +263,17 @@ int main() {
     free(counts);
     free(xdos);
     free(ydos);
-    if (sqrtdiag)
-      free(sqrtdiag);
-    if (fstats != stdout)
+    if (fstats != stdout) {
       fclose(fstats);
+    }
     /*-------------------- end matrix loop */
   }
-  if (flog != stdout)
+  if (flog != stdout) {
     fclose(flog);
+  }
   fclose(fmat);
   /*-------------------- finalize EVSL */
   EVSLFinish();
   return 0;
 }
+

--- a/EVSL_1.0/TESTS/GEN/Lan_MMRLanR.c
+++ b/EVSL_1.0/TESTS/GEN/Lan_MMRLanR.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
 #include <sys/stat.h>
+#include <math.h>
 #include "io.h"
 #include "evsl.h"
 #include "evsl_direct.h"
@@ -25,7 +25,7 @@ int main() {
       totcnt;
   /* find the eigenvalues of A in the interval [a,b] */
   double a, b, lmax, lmin, ecount, tol, *sli;
-  double xintv[6];
+  double xintv[4];
   double *alleigs;
   int *counts; // #ev computed in each slice
   /* initial vector: random */
@@ -36,7 +36,7 @@ int main() {
   double beta = 0.01; // beta in the LS approximation
   /*-------------------- matrices A, B: coo format and csr format */
   cooMat Acoo, Bcoo;
-  csrMat Acsr, Bcsr;
+  csrMat Acsr, Bcsr, Acsr0, Bcsr0;
   double *sqrtdiag = NULL;
   /* slicer parameters */
   int msteps = 40;
@@ -49,8 +49,6 @@ int main() {
   const double tau = 1e-4; // Tolerance in polynomial approximation
   int numat, mat;
   char line[MAX_LINE];
-  /*-------------------- Bsol for B and B^{1/2} */
-  BSolDataPol Bsol, Bsqrtsol;
 #if CXSPARSE == 1
   printf("-----------------------------------------\n");
   printf("Note: You are using CXSparse for the direct solver. \n We recommend a more performance based direct solver for anything more than basic tests. \n SuiteSparse is supported with a makefile change. \n Using SuiteSparse can result in magnitudes faster times. \n ==Additionaly, CXSparse has been known to result in incorrect calculations.== \n\n");
@@ -58,6 +56,8 @@ int main() {
 #endif
   /*-------------------- stopping tol */
   tol = 1e-6;
+  /*-------------------- Polynomial approximation to B and sqrtB*/
+  BSolDataPol Bsol, Bsqrtsol;
   /*-------------------- start EVSL */
   EVSLStart();
   /*------------------ file "matfile" contains paths to matrices */
@@ -93,7 +93,7 @@ int main() {
     }
 
     char path[1024]; // path to write the output files
-    strcpy(path, "OUT/MMRLanR_");
+    strcpy(path, "OUT/Lan_MMRLanR_");
     strcat(path, io.MatNam1);
     fstats = fopen(path, "w"); // write all the output to the file io.MatNam
     if (!fstats) {
@@ -102,20 +102,15 @@ int main() {
     }
     fprintf(fstats, "MATRIX A: %s...\n", io.MatNam1);
     fprintf(fstats, "MATRIX B: %s...\n", io.MatNam2);
-    fprintf(fstats,
-            "Partition the interval of interest [%f,%f] into %d slices\n", a, b,
-            nslices);
+    fprintf(fstats, "Partition the interval of interest [%f,%f] into %d slices\n",
+            a, b, nslices);
     counts = malloc(nslices * sizeof(int));
-    sli = malloc((nslices + 1) * sizeof(double));
     /*-------------------- Read matrix - case: COO/MatrixMarket formats */
     if (io.Fmt > HB) {
       ierr = read_coo_MM(io.Fname1, 1, 0, &Acoo);
       if (ierr == 0) {
         fprintf(fstats, "matrix read successfully\n");
-        // nnz = Acoo.nnz;
         n = Acoo.nrows;
-        // printf("size of A is %d\n", n);
-        // printf("nnz of  A is %d\n", nnz);
       } else {
         fprintf(flog, "read_coo error for A = %d\n", ierr);
         exit(6);
@@ -132,45 +127,47 @@ int main() {
       }
       /*------------------ diagonal scaling for Acoo and Bcoo */
       sqrtdiag = (double *)calloc(n, sizeof(double));
-      extractDiag(&Bcoo, sqrtdiag);
-      diagScaling(&Acoo, &Bcoo, sqrtdiag);
-      /*-------------------- conversion from COO to CSR format */
+      /*------------------ conversion from COO to CSR format */
       ierr = cooMat_to_csrMat(0, &Acoo, &Acsr);
       ierr = cooMat_to_csrMat(0, &Bcoo, &Bcsr);
-    }
-    if (io.Fmt == HB) {
-      fprintf(flog, "HB FORMAT  not supported (yet) * \n");
+    } else if (io.Fmt == HB) {
+      fprintf(flog, "HB FORMAT not supported (yet) * \n");
       exit(7);
     }
-    alleigs = malloc(n * sizeof(double));
-    /*----------------  compute the range of the spectrum of B */
+
+    /*-------------------- diagonal scaling for L-S poly. approx. 
+     *                     of B^{-1} and B^{-1/2},
+     *                     which will be used in the DOS */
+    /*-------------------- sqrt of diag(B) */
+    extrDiagCsr(&Bcsr, sqrtdiag);
+    for (i=0; i<n; i++) {
+      sqrtdiag[i] = sqrt(sqrtdiag[i]);
+    }
+    /*-------------------- backup A and B */
+    csr_copy(&Acsr, &Acsr0, 1); /* 1 stands for memory alloc */
+    csr_copy(&Bcsr, &Bcsr0, 1);
+    /*-------------------- Scale A and B */
+    diagScalCsr(&Acsr, sqrtdiag);
+    diagScalCsr(&Bcsr, sqrtdiag);
+    if (sqrtdiag) {
+      free(sqrtdiag);
+    }
+
+    /*---------------- Set EVSL to solve std eig problem to
+     *---------------- compute the range of the spectrum of B */
     SetStdEig();
     SetAMatrix(&Bcsr);
     vinit = (double *)malloc(n * sizeof(double));
     rand_double(n, vinit);
     ierr = LanTrbounds(50, 200, 1e-10, vinit, 1, &lmin, &lmax, fstats);
-    /*------------- get the bounds for B ------*/
-    xintv[4] = lmin;
-    xintv[5] = lmax;
-    /*---------------  Pass the bounds to Bsol and Bsqrtsol */
-    Bsol.intv[0] = lmin;
-    Bsol.intv[1] = lmax;
-    Bsqrtsol.intv[0] = lmin;
-    Bsqrtsol.intv[1] = lmax;
-    /*--------------  Setup the Bsol and Bsqrtsol struct */
-    set_pol_def(&Bsol.pol_sol);
-    (Bsol.pol_sol).max_deg = degB;
-    (Bsol.pol_sol).tol = tau;
-    SetupBSolPol(&Bcsr, &Bsol);
-    set_pol_def(&Bsqrtsol.pol_sol);
-    (Bsqrtsol.pol_sol).max_deg = degB;
-    (Bsqrtsol.pol_sol).tol = tau;
-    SetupBsqrtSolPol(&Bcsr, &Bsqrtsol);
-    printf("The degree for LS approximations to B^{-1} and B^{-1/2} are %d and "
-           "%d\n",
-           (Bsol.pol_sol).deg, (Bsqrtsol.pol_sol).deg);
-    SetBSol(BSolPol, (void *)&Bsol);
+    /*-------------------- Use polynomial to solve B and sqrt(B) */
+    /*-------------------- Setup the Bsol and Bsqrtsol struct */
+    SetupPolRec (n, degB, tau, lmin, lmax, &Bsol);
+    SetupPolSqrt(n, degB, tau, lmin, lmax, &Bsqrtsol);
+    SetBSol (BSolPol, (void *)&Bsol);
     SetLTSol(BSolPol, (void *)&Bsqrtsol);
+    printf("The degree for LS polynomial approximations to B^{-1} and B^{-1/2} "
+           "are %d and %d\n", Bsol.deg, Bsqrtsol.deg);
     /*-------------------- set the left-hand side matrix A */
     SetAMatrix(&Acsr);
     /*-------------------- set the right-hand side matrix B */
@@ -180,22 +177,21 @@ int main() {
     /*-------------------- step 0: get eigenvalue bounds */
     //-------------------- initial vector
     rand_double(n, vinit);
-    ierr = LanTrbounds(50, 200, 1e-11, vinit, 1, &lmin, &lmax, fstats);
+    ierr = LanTrbounds(50, 200, 1e-10, vinit, 1, &lmin, &lmax, fstats);
     fprintf(fstats, "Step 0: Eigenvalue bound s for B^{-1}*A: [%.15e, %.15e]\n",
             lmin, lmax);
     /*-------------------- interval and eig bounds */
-    xintv[0] = lmin;
-    xintv[1] = lmax;
-    xintv[2] = a;
-    xintv[3] = b;
+    xintv[0] = a;
+    xintv[1] = b;
+    xintv[2] = lmin;
+    xintv[3] = lmax;
     /*-------------------- call landos to get the DOS for dividing the
-     * spectrum*/
+     *                     spectrum*/
     /*-------------------- define landos parameters */
-    //-------------------- call landos
     double t = cheblan_timer();
     double *xdos = (double *)malloc(npts* sizeof(double));
     double *ydos = (double *)malloc(npts* sizeof(double));
-    ierr = LanDosG(nvec, msteps, degB, npts, xdos, ydos, &ecount, xintv, tau);
+    ierr = LanDosG(nvec, msteps, npts, xdos, ydos, &ecount, xintv);
     t = cheblan_timer() - t;
     if (ierr) {
       printf("Landos error %d\n", ierr);
@@ -204,6 +200,7 @@ int main() {
     fprintf(fstats, " Time to build DOS (Landos) was : %10.2f  \n", t);
     fprintf(fstats, " estimated eig count in interval: %.15e \n", ecount);
     //-------------------- call splicer to slice the spectrum
+    sli = malloc((nslices + 1) * sizeof(double));
     fprintf(fstats, "DOS parameters: msteps = %d, nvec = %d, npnts = %d\n",
             msteps, nvec, npts);
     spslicer2(xdos, ydos, nslices, npts, sli);
@@ -211,9 +208,21 @@ int main() {
     for (j = 0; j < nslices; j++) {
       printf(" %2d: [% .15e , % .15e]\n", j + 1, sli[j], sli[j + 1]);
     }
+    /*-------------------- DONE WITH DOS */
+    FreeBSolPolData(&Bsol);
+    FreeBSolPolData(&Bsqrtsol);
+
     //-------------------- # eigs per slice
     ev_int = (int)(1 + ecount / ((double)nslices));
     totcnt = 0;
+    alleigs = malloc(n * sizeof(double));
+ 
+    /* recover the original matrices A and B before scaling 
+     * Note that B-sol and sqrt(B)-sol will not be needed in RatLan,
+     * so we can recover them */
+    csr_copy(&Acsr0, &Acsr, 0); /* 0 stands for no memory alloc */
+    csr_copy(&Bcsr0, &Bcsr, 0);
+
     //-------------------- For each slice call RatLanrNr
     for (sl = 0; sl < nslices; sl++) {
       printf("======================================================\n");
@@ -239,7 +248,7 @@ int main() {
       rat.beta = beta;
       // now determine rational filter
       find_ratf(intv, &rat);
-      // use direct solver function 
+      // use direct solver function
       void **solshiftdata = (void **)malloc(num * sizeof(void *));
       /*------------ factoring the shifted matrices and store the factors */
       SetupASIGMABSolDirect(&Acsr, &Bcsr, num, rat.zk, solshiftdata);
@@ -270,13 +279,11 @@ int main() {
       for (i = 0; i < nev2; i++) {
         fprintf(fstats, "% .15e  %.1e\n", lam[i], res[ind[i]]);
       }
-      fprintf(fstats,
-              "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - "
-              "- - - - - - - - - - - - - -\n");
+      fprintf(fstats, "- - - - - - - - - - - - - - - - - - - - - - - - - - - - "
+                      "- - - - - - - - - - - - - - - - - -\n");
       memcpy(&alleigs[totcnt], lam, nev2 * sizeof(double));
       totcnt += nev2;
       counts[sl] = nev2;
-      ierr = scalEigVec(n, nev2, Y, sqrtdiag);
       //-------------------- free allocated space withing this scope
       if (lam)
         free(lam);
@@ -288,10 +295,10 @@ int main() {
       free(solshiftdata);
       free_rat(&rat);
       free(ind);
-    }
+    } // for (sl=0; sl<nslices; sl++)
     //-------------------- free other allocated space
     fprintf(fstats, " --> Total eigenvalues found = %d\n", totcnt);
-    sprintf(path, "OUT/EigsOut_RLanR_(%s_%s)", io.MatNam1, io.MatNam2);
+    sprintf(path, "OUT/EigsOut_Lan_MMRLanR_(%s_%s)", io.MatNam1, io.MatNam2);
     FILE *fmtout = fopen(path, "w");
     if (fmtout) {
       for (j = 0; j < totcnt; j++)
@@ -304,20 +311,20 @@ int main() {
     free_csr(&Acsr);
     free_coo(&Bcoo);
     free_csr(&Bcsr);
-    FreeBSolPolData(&Bsol);
-    FreeBSolPolData(&Bsqrtsol);
+    free_csr(&Acsr0);
+    free_csr(&Bcsr0);
     free(alleigs);
     free(counts);
     free(xdos);
     free(ydos);
-    if (sqrtdiag)
-      free(sqrtdiag);
-    if (fstats != stdout)
+    if (fstats != stdout) {
       fclose(fstats);
+    }
     /*-------------------- end matrix loop */
   }
-  if (flog != stdout)
+  if (flog != stdout) {
     fclose(flog);
+  }
   fclose(fmat);
   /*-------------------- finalize EVSL */
   EVSLFinish();

--- a/EVSL_1.0/TESTS/GEN/Lap_PLanN.c
+++ b/EVSL_1.0/TESTS/GEN/Lap_PLanN.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[]) {
     mkdir("OUT", 0750);
   }
 
-  if (!(fstats = fopen("OUT/LapPLanN.out","w"))) {
+  if (!(fstats = fopen("OUT/Lap_PLanN.out","w"))) {
     printf(" failed in opening output file in OUT/\n");
     fstats = stdout;
   }

--- a/EVSL_1.0/TESTS/GEN/matfile
+++ b/EVSL_1.0/TESTS/GEN/matfile
@@ -1,6 +1,6 @@
-2
-../../MATRICES/A.mtx ../../MATRICES/B.mtx stiff1 mass1 MM1  28.617629  1746.952 2
+1
 ../../MATRICES/NM1A.mtx ../../MATRICES/NM1B.mtx nm1A nm1B MM1  3.947842e-07, 3.947842e-05 1
+../../MATRICES/A.mtx ../../MATRICES/B.mtx stiff1 mass1 MM1  28.617629  1746.952 2
 ../../MATRICES/A5.mtx ../../MATRICES/B5.mtx stiff5 mass5 MM1  28.617629  1000.952 3
 ../MATRICES/stiff0065536.mtx ../MATRICES/mass0065536.mtx stiff0065536 mass0065536 MM1  0.3  0.6 1
 MATRICES/benzene.mtx benzene MM1 20 23 2

--- a/EVSL_1.0/TESTS/Landos/LanDos.c
+++ b/EVSL_1.0/TESTS/Landos/LanDos.c
@@ -68,9 +68,8 @@ int main(int argc, char *argv[]) {
   cooMat cooMat;
   csrMat csrMat;
 
-  int graph_exact_dos_tmp = 0;
-  findarg("graph_exact_dos", INT, &graph_exact_dos_tmp, argc, argv);
-  const int graph_exact_dos = graph_exact_dos_tmp;
+  int graph_exact_dos = 0;
+  findarg("graph_exact_dos", INT, &graph_exact_dos, argc, argv);
   /*-------------------- Read in a test matrix */
   readDiagMat("testmat.dat", &cooMat);
   cooMat_to_csrMat(0, &cooMat, &csrMat);
@@ -79,26 +78,24 @@ int main(int argc, char *argv[]) {
   const int msteps = 40; /* Steps to perform */
   const int npts = 200;  /* Number of points */
   const int nvec = 100;  /* Number of random vectors to generate */
-  double intv[6] = {-2.448170338612495,
+  /*-------------------- Intervals of interest
+     intv[0] and intv[1] are the input interval of interest [a. b]
+     intv[2] and intv[3] are the smallest and largest eigenvalues of (A,B)
+  */
+  double intv[4] = {-2.448170338612495,
                     11.868902203167497,
-                    0,
-                    0,
-                    5,
-                    8}; /* Interval of interest */
-  /*-------------------- reset to whole interval */
-  intv[2] = intv[0];
-  intv[3] = intv[1];
+                    -2.448170338612495,
+                    11.868902203167497};
   int i, ret;
   double neig; /* Number eigenvalues */
   /*-------------------- exact histogram and computed DOS */
-  double *xHist;
-  double *yHist;
+  double *xHist = NULL;
+  double *yHist = NULL;
   if (graph_exact_dos) {
     xHist = (double *)malloc(npts * sizeof(double)); /*Exact DOS x values */
     yHist = (double *)malloc(npts * sizeof(double)); /* Exact DOS y values */
   }
-  double *xdos =
-      (double *)malloc(npts * sizeof(double)); /* Calculated DOS x vals */
+  double *xdos = (double *)malloc(npts * sizeof(double)); /* Calculated DOS x vals */
   double *ydos = (double *)malloc(npts * sizeof(double)); /* Calculated DOS y */
 
   SetStdEig();

--- a/EVSL_1.0/TESTS/Landos/exDOS.c
+++ b/EVSL_1.0/TESTS/Landos/exDOS.c
@@ -25,14 +25,14 @@ int exDOS(double *vals, int n, int npts,
    we have exp[-0.5 [H/sigma]^2] = 1/K. */
   int i,j=0, one=1;
   double h, xi, t, scaling;
-  const double lm = intv[0];
-  const double lM = intv[1];
+  const double lm = intv[2];
+  const double lM = intv[3];
   const double kappa = 1.25;
   const int M = min(n, 30);
   const double H = (lM - lm) / (M - 1);
   const double sigma = H / sqrt(8 * log(kappa));
-  const double a = intv[2];
-  const double b = intv[3];
+  const double a = intv[0];
+  const double b = intv[1];
   double sigma2 = 2 * sigma * sigma;
 /*-------------------- sigma related..
   -------------------- if gaussian smaller than tol ignore point. */

--- a/EVSL_1.0/TESTS/PLanN/MMPLanN.c
+++ b/EVSL_1.0/TESTS/PLanN/MMPLanN.c
@@ -126,8 +126,8 @@ int main () {
     /*-------------------- define [a b] now so we can get estimates now    
                            on number of eigenvalues in [a b] from kpmdos */
     fprintf(fstats," --> interval: a  %9.3e  b %9.3e \n",a, b);
-    /*-------------------- define kpmdos parameters */
-    xintv[0] = a;  xintv[1] = b;
+    /*-------------------- define LanczosDOS parameters */
+    xintv[0] = a;    xintv[1] = b;
     xintv[2] = lmin; xintv[3] = lmax;
     //-------------------- landos or triv_slicer 
     if (TRIV_SLICER) {

--- a/EVSL_1.0/TESTS/RLanN/MMRLanN.c
+++ b/EVSL_1.0/TESTS/RLanN/MMRLanN.c
@@ -19,7 +19,7 @@ int main () {
    * read in matrix format -- using
    * Thick-Restarted Lanczos with rational filtering.
    *-------------------------------------------------------------*/
-  int n=0, nnz=0, sl, i, j, nev, totcnt; 
+  int n=0, sl, i, j, nev, totcnt; 
   double a, b, ecount, xintv[4];
   double lmin, lmax; 
   double *alleigs; 
@@ -113,10 +113,7 @@ int main () {
       ierr =read_coo_MM(io.Fname, 1, 0, &Acoo); 
       if (ierr == 0) {
         fprintf(fstats,"matrix read successfully\n");
-        nnz = Acoo.nnz; 
         n = Acoo.nrows;
-        printf("size of matrix is %d\n", n);
-        printf("nnz of matrix is %d\n", nnz);
       }
       else {
         fprintf(flog, "read_coo error = %d\n", ierr);

--- a/EVSL_1.0/TESTS/RLanR/MMRLanR.c
+++ b/EVSL_1.0/TESTS/RLanR/MMRLanR.c
@@ -19,7 +19,7 @@ int main () {
    * read in matrix format -- using
    * non-restart Lanczos with rational filtering.
    *-------------------------------------------------------------*/
-  int n=0, nnz=0, sl, i, j, mlan, nev, totcnt; 
+  int n=0, sl, i, j, mlan, nev, totcnt; 
   double a, b, ecount, xintv[4];
   double lmin, lmax; 
   double *alleigs; 
@@ -113,10 +113,7 @@ int main () {
       ierr =read_coo_MM(io.Fname, 1, 0, &Acoo); 
       if (ierr == 0) {
         fprintf(fstats,"matrix read successfully\n");
-        nnz = Acoo.nnz; 
         n = Acoo.nrows;
-        printf("size of matrix is %d\n", n);
-        printf("nnz of matrix is %d\n", nnz);
       }
       else {
         fprintf(flog, "read_coo error = %d\n", ierr);

--- a/EVSL_1.0/makefile.in
+++ b/EVSL_1.0/makefile.in
@@ -46,9 +46,9 @@ ifeq ($(INTEL), 1)
 LIBLAPACK = -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_intel_thread.a ${MKLROOT}/lib/intel64/libmkl_core.a -Wl,--end-group -liomp5 -lpthread -lm -ldl
 else
 #LIBLAPACK = -L/scratch/syphax/Rational_GEIG/lapack-3.5.0 -llapack -lrefblas
-#LIBLAPACK = -L/home/ruipeng/workspace/lapack-3.7.0 -llapack -lrefblas
+LIBLAPACK = -L/home/ruipeng/workspace/lapack-3.7.0 -llapack -lrefblas
 #LIBLAPACK = -L/home/yuanzhe/Desktop/lapack-3.5.0 -llapack -lrefblas
-LIBLAPACK = -llapack -lblas
+#LIBLAPACK = -llapack -lblas
 endif
 
 # direct solver: CXSPARSE, SUITESPARSE


### PR DESCRIPTION
I create this pull request mainly for the latest changes made to LanDOS and corresponding test drivers. There are quite a few changes to many files (some of them were not originally coded by me), so I would like to ask everyone to review before committing to master. 

In general, in our tests for gen. eig. prob. , we will use L-S polynomial for B^{-1} and B^{-1/2} for rational filtering, since we don't to need to have factorization of B there. Diag-scaling was also used with it. Look for it in all RlanR and RlanN. 
We do not use  L-S polynomial for B^{-1} and B^{-1/2} in all the examples with Laplacian matrices 

Thanks!